### PR TITLE
NOISSUE - Improve twin definition editor ergonomy

### DIFF
--- a/src/app/common/services/twins/twins.service.ts
+++ b/src/app/common/services/twins/twins.service.ts
@@ -24,14 +24,11 @@ export class TwinsService {
 
     return this.http.get(environment.twinsUrl, { params })
       .map(
-        resp => {
-          return resp;
-        },
+        resp => resp,
       )
       .catch(
         err => {
-          this.notificationsService.error('Failed to get twins',
-            `Error: ${err.status} - ${err.statusText}`);
+          this.notificationsService.error('Failed to get twins', `Error: ${err.status} - ${err.statusText}`);
           return Observable.throw(err);
         },
       );

--- a/src/app/pages/admin/twins/details/twins.details.component.html
+++ b/src/app/pages/admin/twins/details/twins.details.component.html
@@ -163,7 +163,8 @@
         <div class="col-md-1">
         </div>
       </nb-list-item>
-      <nb-list-item *ngFor="let attr of editAttrs">
+      <nb-list-item *ngFor="let attr of editAttrs"
+                    (click)="selectAttribute(attr)" class="pickable">
         <div class="col-md-2">
           {{ attr.name }}
         </div>

--- a/src/app/pages/admin/twins/details/twins.details.component.ts
+++ b/src/app/pages/admin/twins/details/twins.details.component.ts
@@ -63,7 +63,7 @@ export class TwinsDetailsComponent implements OnInit, OnDestroy {
     this.twinsService.getTwin(id).subscribe(
       resp => {
         this.twin = <Twin>resp;
-        
+
         this.def = this.twin.definitions[this.twin.definitions.length - 1];
         this.defDelta = this.def.delta;
         this.defAttrs = this.def.attributes;
@@ -161,8 +161,17 @@ export class TwinsDetailsComponent implements OnInit, OnDestroy {
   }
 
   addAttribute() {
-    if (!this.editAttr.name || !this.editAttr.channel) {
-      this.notificationsService.error('Missing attribute info', '');
+    if (!this.editAttr.name) {
+      if (this.editAttr.subtopic) {
+        this.notificationsService.warn('Using subtopic as attribute name', '');
+        this.editAttr.name = this.editAttr.subtopic;
+      } else {
+        this.notificationsService.error('Attribute name missing', '')
+        return;
+      }
+    }
+    if (!this.editAttr.channel) {
+      this.notificationsService.error('Attribute channel missing', '');
       return;
     }
 
@@ -190,7 +199,7 @@ export class TwinsDetailsComponent implements OnInit, OnDestroy {
       },
     };
     this.twinsService.editTwin(twin).subscribe(
-      _resp => {
+      resp => {
         this.getTwin(this.twin.id);
       },
     );

--- a/src/app/pages/admin/twins/details/twins.details.component.ts
+++ b/src/app/pages/admin/twins/details/twins.details.component.ts
@@ -6,7 +6,6 @@ import { TwinsService } from 'app/common/services/twins/twins.service';
 import { NotificationsService } from 'app/common/services/notifications/notifications.service';
 import { MessagesService } from 'app/common/services/messages/messages.service';
 import { Thing, Channel, Attribute, Definition, Twin } from 'app/common/interfaces/mainflux.interface';
-import { isNumber } from 'util';
 
 const stateInterval: number = 5 * 1000;
 
@@ -64,9 +63,8 @@ export class TwinsDetailsComponent implements OnInit, OnDestroy {
     this.twinsService.getTwin(id).subscribe(
       resp => {
         this.twin = <Twin>resp;
-
+        
         this.def = this.twin.definitions[this.twin.definitions.length - 1];
-
         this.defDelta = this.def.delta;
         this.defAttrs = this.def.attributes;
         this.defAttrs.forEach(attr => {
@@ -192,15 +190,15 @@ export class TwinsDetailsComponent implements OnInit, OnDestroy {
       },
     };
     this.twinsService.editTwin(twin).subscribe(
-      resp => {
+      _resp => {
         this.getTwin(this.twin.id);
       },
     );
   }
 
-  delta($event) {
-    const val = +$event.srcElement.value;
-    this.defDelta = isNumber(val) ? val * 1e6 : this.defDelta;
+  delta(event: any) {
+    const val = +event.srcElement.value;
+    this.defDelta = typeof(val) == 'number' ? val * 1e6 : this.defDelta;
   }
 
   ngOnDestroy() {

--- a/src/app/pages/admin/twins/twins.component.ts
+++ b/src/app/pages/admin/twins/twins.component.ts
@@ -38,9 +38,7 @@ export class TwinsComponent implements OnInit {
       details: {
         type: 'custom',
         renderComponent: DetailsComponent,
-        valuePrepareFunction: (cell, row) => {
-          return row;
-        },
+        valuePrepareFunction: (_cell: any, row: any) => row,
         editable: false,
         addable: false,
         filter: false,
@@ -56,18 +54,14 @@ export class TwinsComponent implements OnInit {
         editable: false,
         addable: false,
         filter: false,
-        valuePrepareFunction: (cell, row) => {
-          return new Date(cell).toLocaleString();
-        },
+        valuePrepareFunction: (cell: any, _row: any) => new Date(cell).toLocaleString(),
       },
       updated: {
         title: 'Updated',
         editable: false,
         addable: false,
         filter: false,
-        valuePrepareFunction: (cell, row) => {
-          return new Date(cell).toLocaleString();
-        },
+        valuePrepareFunction: (cell: any, _row: any) => new Date(cell).toLocaleString(),
       },
       revision: {
         title: 'Revision',
@@ -112,32 +106,32 @@ export class TwinsComponent implements OnInit {
     );
   }
 
-  onCreateConfirm(event): void {
+  onCreateConfirm(event: any): void {
     // close edditable row
     event.confirm.resolve();
 
     this.twinsService.addTwin(event.newData).subscribe(
-      resp => {
+      _resp => {
         this.getTwins();
       },
     );
   }
 
-  onEditConfirm(event): void {
+  onEditConfirm(event: any): void {
     // close edditable row
     event.confirm.resolve();
 
     this.twinsService.editTwin(event.newData).subscribe();
   }
 
-  onDeleteConfirm(event): void {
+  onDeleteConfirm(event: any): void {
     this.dialogService.open(ConfirmationComponent, { context: { type: 'twin' } }).onClose.subscribe(
       confirm => {
         if (confirm) {
           // close edditable row
           event.confirm.resolve();
           this.twinsService.deleteTwin(event.data.id).subscribe(
-            resp => {
+            _resp => {
               this.getTwins();
             },
           );
@@ -150,9 +144,9 @@ export class TwinsComponent implements OnInit {
     this.fsService.exportToCsv('twins.csv', this.twins);
   }
 
-  onFileSelected(files: FileList) {
+  onFileSelected(_files: FileList) {
   }
 
-  searchThing(input) {
+  searchThing(_input: any) {
   }
 }

--- a/src/app/pages/admin/twins/twins.component.ts
+++ b/src/app/pages/admin/twins/twins.component.ts
@@ -38,7 +38,7 @@ export class TwinsComponent implements OnInit {
       details: {
         type: 'custom',
         renderComponent: DetailsComponent,
-        valuePrepareFunction: (_cell: any, row: any) => row,
+        valuePrepareFunction: (cell: any, row: any) => row,
         editable: false,
         addable: false,
         filter: false,
@@ -54,14 +54,14 @@ export class TwinsComponent implements OnInit {
         editable: false,
         addable: false,
         filter: false,
-        valuePrepareFunction: (cell: any, _row: any) => new Date(cell).toLocaleString(),
+        valuePrepareFunction: (cell: any, row: any) => new Date(cell).toLocaleString(),
       },
       updated: {
         title: 'Updated',
         editable: false,
         addable: false,
         filter: false,
-        valuePrepareFunction: (cell: any, _row: any) => new Date(cell).toLocaleString(),
+        valuePrepareFunction: (cell: any, row: any) => new Date(cell).toLocaleString(),
       },
       revision: {
         title: 'Revision',
@@ -111,7 +111,7 @@ export class TwinsComponent implements OnInit {
     event.confirm.resolve();
 
     this.twinsService.addTwin(event.newData).subscribe(
-      _resp => {
+      resp => {
         this.getTwins();
       },
     );
@@ -131,7 +131,7 @@ export class TwinsComponent implements OnInit {
           // close edditable row
           event.confirm.resolve();
           this.twinsService.deleteTwin(event.data.id).subscribe(
-            _resp => {
+            resp => {
               this.getTwins();
             },
           );
@@ -144,9 +144,9 @@ export class TwinsComponent implements OnInit {
     this.fsService.exportToCsv('twins.csv', this.twins);
   }
 
-  onFileSelected(_files: FileList) {
+  onFileSelected(files: FileList) {
   }
 
-  searchThing(_input: any) {
+  searchThing(input: any) {
   }
 }


### PR DESCRIPTION
Improve twin definition editor ergonomy by enabling attribute selection from the list of already existing attributes and by using subtopic as attribute's name when attribute's name is empty.