### PR TITLE
NOISSUE - Configure charts to display other values

### DIFF
--- a/src/app/common/interfaces/mainflux.interface.ts
+++ b/src/app/common/interfaces/mainflux.interface.ts
@@ -58,7 +58,7 @@ export interface SenMLRec {
   vs: string;
 }
 
-export interface MsgResp {
+export interface MainfluxMsg {
   name: string;
   time: number;
   unit: string;

--- a/src/app/common/interfaces/mainflux.interface.ts
+++ b/src/app/common/interfaces/mainflux.interface.ts
@@ -46,7 +46,7 @@ export interface Twin {
   metadata?: any;
 }
 
-export interface Message {
+export interface SenMLRec {
   bn: string;
   bt: number;
   bu: string;
@@ -56,4 +56,15 @@ export interface Message {
   u: string;
   v: number;
   vs: string;
+}
+
+export interface MsgResp {
+  name: string;
+  time: number;
+  unit: string;
+  value: number;
+  string_value: string;
+  bool_value: boolean;
+  data_value: string;
+  sum: number;
 }

--- a/src/app/common/services/mqtt/mqtt.manager.service.ts
+++ b/src/app/common/services/mqtt/mqtt.manager.service.ts
@@ -2,12 +2,12 @@ import { Injectable, EventEmitter } from '@angular/core';
 import { MqttService, IMqttMessage, MqttConnectionState } from 'ngx-mqtt';
 import { NotificationsService } from 'app/common/services/notifications/notifications.service';
 
-import { Message } from 'app/common/interfaces/mainflux.interface';
+import { SenMLRec } from 'app/common/interfaces/mainflux.interface';
 import { Subscription } from 'rxjs';
 
 @Injectable()
 export class MqttManagerService {
-  public message: Message;
+  public message: SenMLRec;
   messageChange = new EventEmitter();
   connectChange = new EventEmitter();
   subscriptions: Subscription[] = new Array();
@@ -89,7 +89,7 @@ export class MqttManagerService {
     const topicSub = this.mqttService.observe(topic).subscribe(
       (message: IMqttMessage) => {
         const pl = message.payload.toString();
-        this.message = <Message>JSON.parse(pl)[0];
+        this.message = <SenMLRec>JSON.parse(pl)[0];
         this.messageChange.emit(this.message);
       },
     );

--- a/src/app/pages/admin/twins/details/twins.details.component.scss
+++ b/src/app/pages/admin/twins/details/twins.details.component.scss
@@ -7,7 +7,7 @@ nb-icon {
 }
 
 .pickable:hover {
-  background-color: silver;
+  background-color: #F8F8FF;
 }
 
 nb-select {

--- a/src/app/pages/admin/twins/details/twins.details.component.ts
+++ b/src/app/pages/admin/twins/details/twins.details.component.ts
@@ -63,7 +63,7 @@ export class TwinsDetailsComponent implements OnInit, OnDestroy {
     this.twinsService.getTwin(id).subscribe(
       resp => {
         this.twin = <Twin>resp;
-        
+
         this.def = this.twin.definitions[this.twin.definitions.length - 1];
         this.defDelta = this.def.delta;
         this.defAttrs = this.def.attributes;
@@ -199,7 +199,7 @@ export class TwinsDetailsComponent implements OnInit, OnDestroy {
       },
     };
     this.twinsService.editTwin(twin).subscribe(
-      _resp => {
+      resp => {
         this.getTwin(this.twin.id);
       },
     );

--- a/src/app/pages/admin/twins/details/twins.details.component.ts
+++ b/src/app/pages/admin/twins/details/twins.details.component.ts
@@ -5,7 +5,7 @@ import { ChannelsService } from 'app/common/services/channels/channels.service';
 import { TwinsService } from 'app/common/services/twins/twins.service';
 import { NotificationsService } from 'app/common/services/notifications/notifications.service';
 import { MessagesService } from 'app/common/services/messages/messages.service';
-import { Thing, Channel, Attribute, Definition, Twin } from 'app/common/interfaces/mainflux.interface';
+import { Thing, Channel, Attribute, Definition, Twin, MainfluxMsg } from 'app/common/interfaces/mainflux.interface';
 
 const stateInterval: number = 5 * 1000;
 
@@ -117,7 +117,7 @@ export class TwinsDetailsComponent implements OnInit, OnDestroy {
           return;
         }
 
-        const value = this.findValue(msgs.messages[0]);
+        const value = this.parseValue(msgs.messages[0]);
         if (!value) return;
 
         this.state[name] = this.state[name] || {};
@@ -127,14 +127,9 @@ export class TwinsDetailsComponent implements OnInit, OnDestroy {
     );
   }
 
-  findValue(message: any): any {
-    let value: any;
-    if (message.value) value = message.value;
-    if (message.string_value) value = message.string_value;
-    if (message.data_value) value = message.data_value;
-    if (message.bool_value) value = message.bool_value;
-    if (message.sum) value = message.sum;
-    return value;
+  parseValue(message: MainfluxMsg): any {
+    return message.value || message.bool_value ||
+      message.string_value || message.data_value || message.sum;
   }
 
   showStates() {

--- a/src/app/pages/admin/twins/details/twins.details.component.ts
+++ b/src/app/pages/admin/twins/details/twins.details.component.ts
@@ -63,7 +63,7 @@ export class TwinsDetailsComponent implements OnInit, OnDestroy {
     this.twinsService.getTwin(id).subscribe(
       resp => {
         this.twin = <Twin>resp;
-
+        
         this.def = this.twin.definitions[this.twin.definitions.length - 1];
         this.defDelta = this.def.delta;
         this.defAttrs = this.def.attributes;
@@ -199,7 +199,7 @@ export class TwinsDetailsComponent implements OnInit, OnDestroy {
       },
     };
     this.twinsService.editTwin(twin).subscribe(
-      resp => {
+      _resp => {
         this.getTwin(this.twin.id);
       },
     );

--- a/src/app/pages/admin/twins/details/twins.details.component.ts
+++ b/src/app/pages/admin/twins/details/twins.details.component.ts
@@ -131,7 +131,7 @@ export class TwinsDetailsComponent implements OnInit, OnDestroy {
     let value: any;
     if (message.value) value = message.value;
     if (message.string_value) value = message.string_value;
-    if (message.date_value) value = message.date_value;
+    if (message.data_value) value = message.data_value;
     if (message.bool_value) value = message.bool_value;
     if (message.sum) value = message.sum;
     return value;

--- a/src/app/pages/admin/twins/twins.component.ts
+++ b/src/app/pages/admin/twins/twins.component.ts
@@ -111,7 +111,7 @@ export class TwinsComponent implements OnInit {
     event.confirm.resolve();
 
     this.twinsService.addTwin(event.newData).subscribe(
-      _resp => {
+      resp => {
         this.getTwins();
       },
     );
@@ -131,7 +131,7 @@ export class TwinsComponent implements OnInit {
           // close edditable row
           event.confirm.resolve();
           this.twinsService.deleteTwin(event.data.id).subscribe(
-            _resp => {
+            resp => {
               this.getTwins();
             },
           );
@@ -144,7 +144,7 @@ export class TwinsComponent implements OnInit {
     this.fsService.exportToCsv('twins.csv', this.twins);
   }
 
-  onFileSelected(_files: FileList) {
+  onFileSelected(files: FileList) {
   }
 
   searchThing(input: any) {

--- a/src/app/pages/admin/twins/twins.component.ts
+++ b/src/app/pages/admin/twins/twins.component.ts
@@ -111,7 +111,7 @@ export class TwinsComponent implements OnInit {
     event.confirm.resolve();
 
     this.twinsService.addTwin(event.newData).subscribe(
-      resp => {
+      _resp => {
         this.getTwins();
       },
     );
@@ -131,7 +131,7 @@ export class TwinsComponent implements OnInit {
           // close edditable row
           event.confirm.resolve();
           this.twinsService.deleteTwin(event.data.id).subscribe(
-            resp => {
+            _resp => {
               this.getTwins();
             },
           );
@@ -144,7 +144,7 @@ export class TwinsComponent implements OnInit {
     this.fsService.exportToCsv('twins.csv', this.twins);
   }
 
-  onFileSelected(files: FileList) {
+  onFileSelected(_files: FileList) {
   }
 
   searchThing(input: any) {

--- a/src/app/pages/things/channels/details/channels.details.component.ts
+++ b/src/app/pages/things/channels/details/channels.details.component.ts
@@ -5,7 +5,7 @@ import { ThingsService } from 'app/common/services/things/things.service';
 import { ChannelsService } from 'app/common/services/channels/channels.service';
 import { MessagesService } from 'app/common/services/messages/messages.service';
 import { NotificationsService } from 'app/common/services/notifications/notifications.service';
-import { Channel, MsgResp } from 'app/common/interfaces/mainflux.interface';
+import { Channel, MainfluxMsg } from 'app/common/interfaces/mainflux.interface';
 
 @Component({
   selector: 'ngx-channels-details-component',
@@ -20,7 +20,7 @@ export class ChannelsDetailsComponent implements OnInit {
 
   connections = [];
   things = [];
-  messages: MsgResp[] = [];
+  messages: MainfluxMsg[] = [];
 
   selectedThings = [];
   editorMetadata = '';

--- a/src/app/pages/things/channels/details/channels.details.component.ts
+++ b/src/app/pages/things/channels/details/channels.details.component.ts
@@ -5,8 +5,7 @@ import { ThingsService } from 'app/common/services/things/things.service';
 import { ChannelsService } from 'app/common/services/channels/channels.service';
 import { MessagesService } from 'app/common/services/messages/messages.service';
 import { NotificationsService } from 'app/common/services/notifications/notifications.service';
-import { Channel } from 'app/common/interfaces/mainflux.interface';
-
+import { Channel, MsgResp } from 'app/common/interfaces/mainflux.interface';
 
 @Component({
   selector: 'ngx-channels-details-component',
@@ -21,7 +20,7 @@ export class ChannelsDetailsComponent implements OnInit {
 
   connections = [];
   things = [];
-  messages = [];
+  messages: MsgResp[] = [];
 
   selectedThings = [];
   editorMetadata = '';

--- a/src/app/pages/things/devices/details/devices.details.component.ts
+++ b/src/app/pages/things/devices/details/devices.details.component.ts
@@ -5,7 +5,7 @@ import { ThingsService } from 'app/common/services/things/things.service';
 import { ChannelsService } from 'app/common/services/channels/channels.service';
 import { MessagesService } from 'app/common/services/messages/messages.service';
 import { NotificationsService } from 'app/common/services/notifications/notifications.service';
-import { Thing, MsgResp } from 'app/common/interfaces/mainflux.interface';
+import { Thing, MainfluxMsg } from 'app/common/interfaces/mainflux.interface';
 
 
 @Component({
@@ -21,7 +21,7 @@ export class DevicesDetailsComponent implements OnInit {
 
   connections = [];
   channels = [];
-  messages: MsgResp[] = [];
+  messages: MainfluxMsg[] = [];
 
   selectedChannels = [];
   editorMetadata = '';

--- a/src/app/pages/things/devices/details/devices.details.component.ts
+++ b/src/app/pages/things/devices/details/devices.details.component.ts
@@ -5,7 +5,7 @@ import { ThingsService } from 'app/common/services/things/things.service';
 import { ChannelsService } from 'app/common/services/channels/channels.service';
 import { MessagesService } from 'app/common/services/messages/messages.service';
 import { NotificationsService } from 'app/common/services/notifications/notifications.service';
-import { Thing } from 'app/common/interfaces/mainflux.interface';
+import { Thing, MsgResp } from 'app/common/interfaces/mainflux.interface';
 
 
 @Component({
@@ -21,7 +21,7 @@ export class DevicesDetailsComponent implements OnInit {
 
   connections = [];
   channels = [];
-  messages = [];
+  messages: MsgResp[] = [];
 
   selectedChannels = [];
   editorMetadata = '';

--- a/src/app/pages/things/gateways/details/xterm/gateways.xterm.component.ts
+++ b/src/app/pages/things/gateways/details/xterm/gateways.xterm.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, AfterViewInit,
   ViewChild, ElementRef, ViewEncapsulation, OnChanges, OnDestroy } from '@angular/core';
 import { Gateway } from 'app/common/interfaces/gateway.interface';
-import { Message } from 'app/common/interfaces/mainflux.interface';
+import { SenMLRec } from 'app/common/interfaces/mainflux.interface';
 import { Terminal } from 'xterm';
 import { MqttService, IMqttMessage, MqttConnectionState } from 'ngx-mqtt';
 import { NotificationsService } from 'app/common/services/notifications/notifications.service';
@@ -67,7 +67,7 @@ export class GatewaysXtermComponent implements AfterViewInit, OnChanges, OnDestr
           let res: string;
           const pl = message.payload.toString();
           res = JSON.parse(pl);
-          const msg = <Message>(<any>res[0]);
+          const msg = <SenMLRec>(<any>res[0]);
           term.write(msg.vs);
         });
       this.notificationsService.success(`Subscribed to channel ${topic}`, '');

--- a/src/app/shared/chart/chart.component.ts
+++ b/src/app/shared/chart/chart.component.ts
@@ -3,7 +3,7 @@ import { Component, Input, OnChanges, ViewChild } from '@angular/core';
 import { ChartDataSets, ChartType, ChartOptions, ChartPoint } from 'chart.js';
 import { BaseChartDirective, Color } from 'ng2-charts';
 import { COLORS } from './chart.colors';
-import { MsgResp } from 'app/common/interfaces/mainflux.interface';
+import { MainfluxMsg } from 'app/common/interfaces/mainflux.interface';
 
 @Component({
   selector: 'ngx-chart',
@@ -37,7 +37,7 @@ export class ChartComponent implements OnChanges {
   datasetsList: any[] = [];
   chartType: ChartType = 'scatter';
 
-  @Input() messages: MsgResp[];
+  @Input() messages: MainfluxMsg[];
   @ViewChild(BaseChartDirective, { static: false }) chart: BaseChartDirective;
   constructor(
   ) { }
@@ -63,7 +63,7 @@ export class ChartComponent implements OnChanges {
       result.forEach( msg => {
         const point: ChartPoint = {
           x: msg.time * 1000,
-          y: this.findValue(msg),
+          y: this.parseValue(msg),
         };
         chartDataSets[0].label = `${msg.name}`,
 
@@ -75,14 +75,9 @@ export class ChartComponent implements OnChanges {
     });
   }
 
-  findValue(message: MsgResp): any {
-    let value: any;
-    if (message.value) value = message.value;
-    if (message.string_value) value = message.string_value;
-    if (message.data_value) value = message.data_value;
-    if (message.bool_value) value = message.bool_value;
-    if (message.sum) value = message.sum;
-    return value;
+  parseValue(message: MainfluxMsg): any {
+    return message.value || message.bool_value ||
+      message.string_value || message.data_value || message.sum;
   }
   
 }

--- a/src/app/shared/chart/chart.component.ts
+++ b/src/app/shared/chart/chart.component.ts
@@ -3,6 +3,7 @@ import { Component, Input, OnChanges, ViewChild } from '@angular/core';
 import { ChartDataSets, ChartType, ChartOptions, ChartPoint } from 'chart.js';
 import { BaseChartDirective, Color } from 'ng2-charts';
 import { COLORS } from './chart.colors';
+import { MsgResp } from 'app/common/interfaces/mainflux.interface';
 
 @Component({
   selector: 'ngx-chart',
@@ -26,19 +27,17 @@ export class ChartComponent implements OnChanges {
       easing: 'linear',
     },
     scales: {
-        xAxes: [{
-            type: 'time',
-            time: {
-              unit: 'hour',
-            },
-        }],
+      xAxes: [{
+        type: 'time',
+        distribution: 'series',
+      }],
     },
   };
 
   datasetsList: any[] = [];
   chartType: ChartType = 'scatter';
 
-  @Input() messages: any[];
+  @Input() messages: MsgResp[];
   @ViewChild(BaseChartDirective, { static: false }) chart: BaseChartDirective;
   constructor(
   ) { }
@@ -64,7 +63,7 @@ export class ChartComponent implements OnChanges {
       result.forEach( msg => {
         const point: ChartPoint = {
           x: msg.time * 1000,
-          y: msg.value,
+          y: this.findValue(msg),
         };
         chartDataSets[0].label = `${msg.name}`,
 
@@ -75,4 +74,15 @@ export class ChartComponent implements OnChanges {
       this.chart && this.chart.update();
     });
   }
+
+  findValue(message: MsgResp): any {
+    let value: any;
+    if (message.value) value = message.value;
+    if (message.string_value) value = message.string_value;
+    if (message.data_value) value = message.data_value;
+    if (message.bool_value) value = message.bool_value;
+    if (message.sum) value = message.sum;
+    return value;
+  }
+  
 }


### PR DESCRIPTION
Currently, charts only display number values. Enable the display of other types of values, such as booleans, too.