### PR TITLE
NOISSUE - separate nginx entrypoint for ui and main nginx

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -28,7 +28,7 @@ services:
     container_name: mainflux-ui
     restart: on-failure
     volumes:
-      - ./nginx/entrypoint.sh:/entrypoint.sh
+      - ./nginx/entrypoint-ui.sh:/entrypoint.sh
     ports:
       - ${MF_UI_PORT}:${MF_UI_PORT}
     networks:

--- a/docker/nginx/entrypoint-ui.sh
+++ b/docker/nginx/entrypoint-ui.sh
@@ -1,0 +1,5 @@
+#!/bin/ash
+
+envsubst < /usr/share/nginx/html/assets/env.template.js > /usr/share/nginx/html/assets/env.js
+
+exec nginx -g "daemon off;"

--- a/docker/nginx/entrypoint.sh
+++ b/docker/nginx/entrypoint.sh
@@ -19,6 +19,4 @@ envsubst '
     ${MF_TWINS_HTTP_PORT}
     ${MF_OPCUA_ADAPTER_HTTP_PORT}' < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf
 
-envsubst < /usr/share/nginx/html/assets/env.template.js > /usr/share/nginx/html/assets/env.js
-
 exec nginx -g "daemon off;"


### PR DESCRIPTION
Signed-off-by: Mirko Teodorovic <mirko.teodorovic@gmail.com>

When starting the `mainflux-nginx` there is an error reported
``` 
/entrypoint.sh: line 22: can't open /usr/share/nginx/html/assets/env.template.js: no such file
```
Since `env.template.js` is distrubuted in `mainflux-ui` 
both `mainflux-ui` and `mainflux-nginx` were using same entrypoint.sh